### PR TITLE
OrbitCameraSystem PhysicsWorld needs `[ReadOnly]`

### DIFF
--- a/Platformer/Assets/Scripts/Camera/OrbitCameraSystem.cs
+++ b/Platformer/Assets/Scripts/Camera/OrbitCameraSystem.cs
@@ -101,7 +101,7 @@ public partial struct OrbitCameraSystem : ISystem
     public partial struct OrbitCameraJob : IJobEntity
     {
         public TimeData TimeData;
-        public PhysicsWorld PhysicsWorld;
+        [ReadOnly] public PhysicsWorld PhysicsWorld;
 
         public ComponentLookup<LocalToWorld> LocalToWorldLookup;
         [ReadOnly] public ComponentLookup<KinematicCharacterBody> KinematicCharacterBodyLookup;


### PR DESCRIPTION
If not any other system trying to access PhysicsWorld creates error if other systems tries to read at same time.

``
InvalidOperationException: The previously scheduled job StatefulCollisionEventSystem:WriteEventsJob reads from the UNKNOWN_OBJECT_TYPE WriteEventsJob.JobData.PhysicsWorld.CollisionWorld.m_Bodies. You are trying to schedule a new job OrbitCameraSystem:OrbitCameraJob, which writes to the same UNKNOWN_OBJECT_TYPE (via OrbitCameraJob.JobData.PhysicsWorld.CollisionWorld.m_Bodies). To guarantee safety, you must include StatefulCollisionEventSystem:WriteEventsJob as a dependency of the newly scheduled job. Unity.Jobs.LowLevel.Unsafe.JobsUtility.Schedule (Unity.Jobs.LowLevel.Unsafe.JobsUtility+JobScheduleParameters& parameters) <0x441438f0 + 0x00063> in <9b0471513ec64d3c8e9cd9485ce8df42>:0 Unity.Entities.JobChunkExtensions.ScheduleInternal[T] (T& jobData, Unity.Entities.EntityQuery query, Unity.Jobs.JobHandle dependsOn, Unity.Jobs.LowLevel.Unsafe.ScheduleMode mode, Unity.Collections.NativeArray`1[T] chunkBaseEntityIndices) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/IJobChunk.cs:327) Unity.Entities.JobChunkExtensions.ScheduleByRef[T] (T& jobData, Unity.Entities.EntityQuery query, Unity.Jobs.JobHandle dependsOn) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/IJobChunk.cs:158) OrbitCameraSystem+OrbitCameraJob+InternalCompilerQueryAndHandleData.Schedule (OrbitCameraSystem+OrbitCameraJob& job, Unity.Entities.EntityQuery query, Unity.Jobs.JobHandle dependency) (at JobEntityGenerator/Unity.Entities.SourceGen.JobEntityGenerator.JobEntityGenerator/Temp/GeneratedCode/Platformers.Data/OrbitCameraSystem__JobEntity_155907095591.g.cs:208) OrbitCameraSystem.__ScheduleViaJobChunkExtension_0 (OrbitCameraSystem+OrbitCameraJob job, Unity.Entities.EntityQuery query, Unity.Jobs.JobHandle dependency, Unity.Entities.SystemState& state, System.Boolean hasUserDefinedQuery) (at <0ab3346255cd47c7a013d729d3355084>:0) OrbitCameraSystem.OnUpdate (Unity.Entities.SystemState& state) (at Assets/Scripts/Platformers/Platformers.Data/Camera/OrbitCameraSystem.cs:89) OrbitCameraSystem.__codegen__OnUpdate (System.IntPtr self, System.IntPtr state) (at <0ab3346255cd47c7a013d729d3355084>:0) Unity.Entities.SystemBaseRegistry+<>c__DisplayClass9_0.<SelectBurstFn>b__0 (System.IntPtr system, System.IntPtr state) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/SystemBaseRegistry.cs:249) UnityEngine.Debug:LogException(Exception)
Unity.Debug:LogException(Exception) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/Stubs/Unity/Debug.cs:17) Unity.Entities.<>c__DisplayClass9_0:<SelectBurstFn>b__0(IntPtr, IntPtr) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/SystemBaseRegistry.cs:253) Unity.Entities.UnmanagedUpdate_000015D9$BurstDirectCall:wrapper_native_indirect_0x5d48d25ea420(IntPtr&, Void*) Unity.Entities.UnmanagedUpdate_000015D9$BurstDirectCall:Invoke(Void*) Unity.Entities.WorldUnmanagedImpl:UnmanagedUpdate(Void*) Unity.Entities.WorldUnmanagedImpl:UpdateSystem(SystemHandle) (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/WorldUnmanaged.cs:895) Unity.Entities.ComponentSystemGroup:UpdateAllSystems() (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/ComponentSystemGroup.cs:709) Unity.Entities.ComponentSystemGroup:OnUpdate() (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/ComponentSystemGroup.cs:679) Unity.Entities.SystemBase:Update() (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/SystemBase.cs:420) Unity.Entities.DummyDelegateWrapper:TriggerUpdate() (at ./Library/PackageCache/com.unity.entities@f850441486df/Unity.Entities/ScriptBehaviourUpdateOrder.cs:523)
``


By default As the project as it is it doesn't create any error.
But with modification like this it pops up. (In other places also but error massage isn't that clear on those states but no native array was writable if it was in `[UpdateInGroup(typeof(PhysicsSystemGroup))]` and you used  `StatefulCollisionEvent` which reads from RigidBody as cascading error it didn't provide any helpful message thankfully this does)
To recreate this issue add this script to project.

```cs
using BovineLabs.Core.PhysicsStates;
using Unity.Entities;
using Unity.Mathematics;
using Unity.Physics;
using Unity.Physics.Systems;
using UnityEngine;


public struct CollisionDamage : IComponentData
{
    public float BaseDamage;
    public float HeadOnMultiplier;
    public float MinDotProduct;
}

[UpdateInGroup(typeof(PhysicsSystemGroup))]
public partial struct HeadOnCollisionDamageSystem : ISystem
{
    public void OnUpdate(ref SystemState state)
    {
        foreach (var (collisionBuffer, entity) in
                 SystemAPI.Query<DynamicBuffer<StatefulCollisionEvent>>()
                     .WithEntityAccess())
        {
            if (!SystemAPI.HasComponent<PhysicsVelocity>(entity) ||
                !SystemAPI.HasComponent<CollisionDamage>(entity))
                continue;

            var movementDir = SystemAPI.GetComponent<PhysicsVelocity>(entity);
            var damageSettings = SystemAPI.GetComponent<CollisionDamage>(entity);

            for (int i = 0; i < collisionBuffer.Length; i++)
            {
                var collision = collisionBuffer[i];

                if (collision.State != StatefulEventState.Enter)
                    continue;


                float damageAmount = CalculateCollisionDamage(
                    movementDir.Linear,
                    collision.Normal,
                    damageSettings,
                    collision);

                if (damageAmount > 0)
                {
                    Debug.Log($"Head-on collision! Damage: {damageAmount}");
                }
            }
        }
    }

    private float CalculateCollisionDamage(
        float3 movementDirection,
        float3 collisionNormal,
        CollisionDamage damageSettings,
        StatefulCollisionEvent collision)
    {
        float3 normalizedMovement = math.normalize(movementDirection);
        float3 normalizedCollisionNormal = math.normalize(collisionNormal);

        float dotProduct = math.dot(normalizedMovement, normalizedCollisionNormal);

        if (dotProduct < damageSettings.MinDotProduct)
        {
            float headOnFactor = math.abs(dotProduct);
            float damage = damageSettings.BaseDamage;

            damage *= (1.0f + (damageSettings.HeadOnMultiplier * headOnFactor));

            if (collision.TryGetDetails(out var details))
            {
                float impulseFactor = math.min(details.EstimatedImpulse * 0.1f, 2.0f);
                damage *= impulseFactor;
            }

            return damage;
        }

        return 0;
    }
}


public class CollisionDamageAuthoring : UnityEngine.MonoBehaviour
{
    public float baseDamage = 10f;
    public float headOnMultiplier = 2f;
    [Range(-1f, 0f)] public float minDotProductForHeadOn = -0.8f;
    public float maxHealth = 100f;

    class Baker : Baker<CollisionDamageAuthoring>
    {
        public override void Bake(CollisionDamageAuthoring authoring)
        {
            var entity = GetEntity(TransformUsageFlags.Dynamic);

            AddComponent(entity, new CollisionDamage
            {
                BaseDamage = authoring.baseDamage,
                HeadOnMultiplier = authoring.headOnMultiplier,
                MinDotProduct = authoring.minDotProductForHeadOn
            });
        }
    }
}
```

Tested Orbit camera and its features. It doesn't create any error even if other parts like bodies gets modifed from it is called
`var hitBody = PhysicsWorld.Bodies[collector.ClosestHit.RigidBodyIndex]; // line 245 OrbitCameraSystem in Platfromer` 